### PR TITLE
fix: rename variable 'counter' to 'token' for clarity in the GenericERC20Module

### DIFF
--- a/ignition/modules/main.ts
+++ b/ignition/modules/main.ts
@@ -1,9 +1,9 @@
 import { buildModule } from "@nomicfoundation/hardhat-ignition/modules";
 
 const GenericERC20Module = buildModule("GenericERC20Module", (m) => {
-  const counter = m.contract("GenericERC20", ["GenericERC20", "GT"]);
+  const token = m.contract("GenericERC20", ["GenericERC20", "GT"]);
 
-  return { counter };
+  return { token };
 });
 
 export default GenericERC20Module;


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Rename variable 'counter' to 'token' for clarity in the GenericERC20Module.